### PR TITLE
Fix TypeScript typings export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,4 +55,6 @@ declare interface PostcssModulesPlugin {
   postcss: true;
 }
 
+declare const PostcssModulesPlugin: PostcssModulesPlugin;
+
 export = PostcssModulesPlugin;


### PR DESCRIPTION
Fix the TypeScript error: `PostcssModulesPlugin only refers to a type, but is being used as a value here.`

Follow-up: #123

Sorry for my mistake :bow: