### PR TITLE
feat(#13): add custom lookup path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,24 @@ Style of exported classnames, the keys in your json.
 
 In lieu of a string, a custom function can generate the exported class names.
 
+### Resolve path alias
+
+You can rewrite paths for `composes/from` by using `resolve` options. 
+It's useful when you need to resolve custom path alias.
+
+```js
+postcss([
+  require("postcss-modules")({
+    resolve: function (file) {
+     return file.replace(/^@/, process.cwd());
+    },
+  }),
+]);
+```
+
+`resolve` may also return a `Promise<string>`.
+
+
 ## Integration with templates
 
 The plugin only transforms CSS classes to CSS modules.

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,8 @@ declare interface Options {
   root?: string;
 
   Loader?: typeof Loader;
+
+  resolve?: (file: string) => string | Promise<string>;
 }
 
 declare interface PostcssModulesPlugin {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -303,6 +303,19 @@ exports[`processes globalModulePaths option: processes globalModulePaths option 
 
 exports[`processes hashPrefix option: processes hashPrefix option 1`] = `"._8xPWf {}"`;
 
+exports[`processes resolve option: processes resolve option 1`] = `
+"._composes_a_another-mixin {
+    display: flex;
+    height: 100px;
+    width: 200px;
+}._composes_a_hello {
+    foo: bar;
+}._compose_resolve_figure {
+    display: flex;
+}
+"
+`;
+
 exports[`processes values: processes values - CSS 1`] = `
 "
 

--- a/test/fixtures/in/compose.resolve.css
+++ b/test/fixtures/in/compose.resolve.css
@@ -1,0 +1,4 @@
+.figure {
+    composes: hello from "test-fixture-in/composes.a.css";
+    display: flex;
+}


### PR DESCRIPTION
This feature is to provide an option `resolve(path: string): Promise<String> | string` to rewrite paths from `compose/from`.
