### PR TITLE
fix: provide an unquoted path argument for opt.resolve(path)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import postcss from "postcss";
 import camelCase from "lodash.camelcase";
 import genericNames from "generic-names";
+import unquote from './unquote';
 
 import Parser from "./css-loader-core/parser";
 import FileSystemLoader from "./css-loader-core/loader";
@@ -86,11 +87,12 @@ module.exports = (opts = {}) => {
       const loaderPlugins = [...earlierPlugins, ...pluginList];
       const loader = getLoader(opts, loaderPlugins);
       const fetcher = ((file, relativeTo, depTrace) => {
-        const resolvedResult = (typeof opts.resolve === 'function' && opts.resolve(file));
+        const unquoteFile = unquote(file);
+        const resolvedResult = (typeof opts.resolve === 'function' && opts.resolve(unquoteFile));
         const resolvedFile = resolvedResult instanceof Promise ? resolvedResult : Promise.resolve(resolvedResult);
 
-        return resolvedFile.then((f = file) => {
-          return loader.fetch.call(loader, f || file, relativeTo, depTrace);
+        return resolvedFile.then((f) => {
+          return loader.fetch.call(loader, `"${f || unquoteFile}"`, relativeTo, depTrace);
         });
       });
       const parser = new Parser(fetcher);

--- a/src/unquote/index.js
+++ b/src/unquote/index.js
@@ -1,0 +1,16 @@
+// copied from https://github.com/lakenen/node-unquote
+
+var reg = /['"]/;
+
+export default function unquote(str) {
+  if (!str) {
+    return "";
+  }
+  if (reg.test(str.charAt(0))) {
+    str = str.substr(1);
+  }
+  if (reg.test(str.charAt(str.length - 1))) {
+    str = str.substr(0, str.length - 1);
+  }
+  return str;
+}

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -310,8 +310,14 @@ exports[`processes resolve option: processes resolve option 1`] = `
     width: 200px;
 }._composes_a_hello {
     foo: bar;
-}._compose_resolve_figure {
+}
+
+._compose_resolve_figure {
     display: flex;
+}
+
+._compose_resolve_figure-single-quote {
+    display: block;
 }
 "
 `;

--- a/test/fixtures/in/compose.resolve.css
+++ b/test/fixtures/in/compose.resolve.css
@@ -2,3 +2,8 @@
     composes: hello from "test-fixture-in/composes.a.css";
     display: flex;
 }
+
+.figure-single-quote {
+    composes: hello from 'test-fixture-in/composes.a.css';
+    display: block;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -396,7 +396,7 @@ it("processes resolve option", async () => {
     plugin({
       generateScopedName,
       resolve: async (file) => {
-        return file.replace(/test-fixture-in/, path.dirname(sourceFile));
+        return file.replace(/^test-fixture-in/, path.dirname(sourceFile));
       },
       getJSON: (_, result) => {
         json = result;
@@ -405,5 +405,9 @@ it("processes resolve option", async () => {
   ]).process(source, { from: sourceFile });
 
   expect(result.css).toMatchSnapshot("processes resolve option");
-  expect(json).toMatchObject({"figure": "_compose_resolve_figure _composes_a_hello"});
+  expect(json).toStrictEqual({
+    figure: "_compose_resolve_figure _composes_a_hello",
+    "figure-single-quote":
+      "_compose_resolve_figure-single-quote _composes_a_hello",
+  });
 });


### PR DESCRIPTION
Argument path is a quoted string In `opt.resolve(path)` which is not convient for user to use this api.
Also, it is not an expected behaviour for pr #126.

For example:
```css
.a {
  compose: b from "@/scss/compose.css";
}
```

Current behaviour:
```js
postcssModules({
  resolve(path) {
     console.log(path) // "\"@/scss/compose.css\""
  }
})
```

Expected behaviour:
```js
postcssModules({
  resolve(path) {
     console.log(path) // "@/scss/compose.css"
  }
})
```

Sorry for my mistake.