### PR TITLE
Use `localByDefault` plugin for both local and global behaviours.

### DIFF
--- a/src/behaviours.js
+++ b/src/behaviours.js
@@ -16,8 +16,8 @@ export function getDefaultPlugins({
   const scope = modulesScope({ generateScopedName, exportGlobals });
 
   const plugins = {
-    [behaviours.LOCAL]: [values, localByDefault, extractImports, scope],
-    [behaviours.GLOBAL]: [values, extractImports, scope],
+    [behaviours.LOCAL]: [values, localByDefault({ mode: 'local' }), extractImports, scope],
+    [behaviours.GLOBAL]: [values, localByDefault({ mode: 'global' }), extractImports, scope],
   };
 
   return plugins[behaviour];

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -202,6 +202,22 @@ p {
 "
 `;
 
+exports[`only calls plugins once when it processes :global shorthand selector: plugins once - processes :global shorthand selector - CSS 1`] = `
+"/* validator-2-start (globalShorthand.css) *//* validator-1-start (globalShorthand.css) */
+.title {
+    color: red;
+}/* validator-1-end (globalShorthand.css) *//* validator-2-end (globalShorthand.css) */
+"
+`;
+
+exports[`only calls plugins once when it processes :local shorthand selector: plugins once - processes :local shorthand selector - CSS 1`] = `
+"/* validator-2-start (localShorthand.css) *//* validator-1-start (localShorthand.css) */
+._localShorthand_title {
+    color: red;
+}/* validator-1-end (localShorthand.css) *//* validator-2-end (localShorthand.css) */
+"
+`;
+
 exports[`only calls plugins once when it processes classes: plugins once - processes classes - CSS 1`] = `
 "/* validator-2-start (classes.css) */
 
@@ -267,6 +283,28 @@ p {
 `;
 
 exports[`preserves comments: preserves comments - JSON 1`] = `Object {}`;
+
+exports[`processes :global shorthand selector: processes :global shorthand selector - CSS 1`] = `
+".title {
+    color: red;
+}
+"
+`;
+
+exports[`processes :global shorthand selector: processes :global shorthand selector - JSON 1`] = `Object {}`;
+
+exports[`processes :local shorthand selector: processes :local shorthand selector - CSS 1`] = `
+"._localShorthand_title {
+    color: red;
+}
+"
+`;
+
+exports[`processes :local shorthand selector: processes :local shorthand selector - JSON 1`] = `
+Object {
+  "title": "_localShorthand_title",
+}
+`;
 
 exports[`processes classes: processes classes - CSS 1`] = `
 ".page {

--- a/test/fixtures/in/globalShorthand.css
+++ b/test/fixtures/in/globalShorthand.css
@@ -1,0 +1,3 @@
+:global .title {
+    color: red;
+}

--- a/test/fixtures/in/localShorthand.css
+++ b/test/fixtures/in/localShorthand.css
@@ -1,0 +1,3 @@
+:local .title {
+    color: red;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,8 @@ const cases = {
   values: "processes values",
   interpolated: "generates scoped name with interpolated string",
   global: "allows to make CSS global",
+  localShorthand: "processes :local shorthand selector",
+  globalShorthand: "processes :global shorthand selector",
 };
 
 function generateScopedName(name, filename) {
@@ -40,7 +42,9 @@ Object.keys(cases).forEach((name) => {
       : generateScopedName;
 
   const scopeBehaviour =
-    name === behaviours.GLOBAL ? behaviours.GLOBAL : behaviours.LOCAL;
+    name === behaviours.GLOBAL || name === "globalShorthand"
+      ? behaviours.GLOBAL
+      : behaviours.LOCAL;
 
   it(description, async () => {
     const sourceFile = path.join(fixturesPath, "in", `${name}.css`);


### PR DESCRIPTION
The `postcss-modules-local-by-default` plugin actually has the modes `local`, `global` and `pure` ([link](https://github.com/css-modules/postcss-modules-local-by-default/blob/master/src/index.js#L422)).

If the plugin is NOT added in the `global` case, shorthand selectors ([link](https://github.com/css-modules/postcss-modules-local-by-default/blob/master/README.md)) will result in an error.

Shorthand selectors are actually quite useful in SCSS with nesting.

**SCSS**

```scss
:local {
  .foo {
    color: red;
  }

  .bar {
    color: blue;
  }
}
```

**CSS**

```css
:local .layer {
  color: red;
}

:local .bar {
  color: blue;
}
```

The resulting error message (without using the plugin) is:

```
Unexpected comma (",") in :local block
```

Adding the `postcss-modules-local-by-default` plugin with the correct `global` mode will enable this syntax.

---

I created this first commit directly on github.com. I can add some test cases to this PR later.