### PR TITLE
fix: composes on windows

### DIFF
--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -10,12 +10,13 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node-version: [10.x, 12.x, 14.x, 15.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR fixes `composes from '...'` not working on windows.
The tests are already covered so I just enabled github actions with Windows.

refs https://github.com/css-modules/css-modules-loader-core/issues/16, https://github.com/vitejs/vite/issues/3092
