### PR TITLE
Add 'all' and 'none' localsConvention modes and array return from function form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 npm-debug.log
 index.es5.js
 undefined.json
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 8.2.0
+
+### Added
+
+- New `localsConvention` value `'all'` — emit the original class name plus the camelCase and dashes-camelCase variants in one pass.
+- New `localsConvention` value `'none'` — emit only the original class name, with no additional aliases.
+- The function form of `localsConvention` may now return an array of strings. Every entry in the array is added to the locals map and resolves to the same value, which makes it easy to expose a single CSS class under multiple JS-friendly aliases.
+
+Adapted from the unmerged work in [#154](https://github.com/madyankin/postcss-modules/pull/154) by @CarbonORM.
+
 ## 8.1.0
 
 ### Internal

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ postcss([
 
 ### localsConvention
 
-Type: `String | (originalClassName: string, generatedClassName: string, inputFile: string) => className: (string | string[])`
+Type: `String | (originalClassName: string, generatedClassName: string, inputFile: string) => string | string[]`
 Default: `null`
 
 Style of exported classnames, the keys in your json.
@@ -202,10 +202,30 @@ Style of exported classnames, the keys in your json.
 | **`'camelCaseOnly'`** | `{String}` | Class names will be camelized, the original class name will be removed from the locals           |
 |    **`'dashes'`**     | `{String}` | Only dashes in class names will be camelized                                                     |
 |  **`'dashesOnly'`**   | `{String}` | Dashes in class names will be camelized, the original class name will be removed from the locals |
-|      **`'all'`**      | `{String}` | Apply camelCase, dashes, and the original naming convention                                      |
-|     **`'none'`**      | `{String}` | Use only the original class names, with no additional locals                                     |
+|      **`'all'`**      | `{String}` | Emit the original class name plus the camelCase and dashes-camelCase variants                    |
+|     **`'none'`**      | `{String}` | Emit only the original class name (equivalent to leaving `localsConvention` unset)               |
 
-In lieu of a string, a custom function can generate the exported class names. The function may return either a single string or an array of strings; when an array is returned every entry is added to the locals map and resolves to the same value.
+For an input class `foo-bar` resolving to scoped name `_a`:
+
+| Mode            | Emitted locals                                                                              |
+| --------------- | ------------------------------------------------------------------------------------------- |
+| `camelCase`     | `{ "foo-bar": "_a", "fooBar": "_a" }`                                                       |
+| `camelCaseOnly` | `{ "fooBar": "_a" }`                                                                        |
+| `dashes`        | `{ "foo-bar": "_a", "fooBar": "_a" }`                                                       |
+| `dashesOnly`    | `{ "fooBar": "_a" }`                                                                        |
+| `all`           | `{ "foo-bar": "_a", "fooBar": "_a" }` (camelCase + dashesCamelCase collapse for this input) |
+| `none`          | `{ "foo-bar": "_a" }`                                                                       |
+
+In lieu of a string, a custom function can generate the exported class names. The function may return either a single string or an array of strings; when an array is returned every entry is added to the locals map and resolves to the same value:
+
+```js
+postcss([
+	require("postcss-modules")({
+		localsConvention: (original, generated) => [original, generated, original.toUpperCase()],
+	}),
+]);
+// .foo-bar { ... }  →  { "foo-bar": "_a", "_a": "_a", "FOO-BAR": "_a" }
+```
 
 ### Resolve path alias
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ postcss([
 
 ### localsConvention
 
-Type: `String | (originalClassName: string, generatedClassName: string, inputFile: string) => className: string`
+Type: `String | (originalClassName: string, generatedClassName: string, inputFile: string) => className: (string | string[])`
 Default: `null`
 
 Style of exported classnames, the keys in your json.
@@ -202,8 +202,10 @@ Style of exported classnames, the keys in your json.
 | **`'camelCaseOnly'`** | `{String}` | Class names will be camelized, the original class name will be removed from the locals           |
 |    **`'dashes'`**     | `{String}` | Only dashes in class names will be camelized                                                     |
 |  **`'dashesOnly'`**   | `{String}` | Dashes in class names will be camelized, the original class name will be removed from the locals |
+|      **`'all'`**      | `{String}` | Apply camelCase, dashes, and the original naming convention                                      |
+|     **`'none'`**      | `{String}` | Use only the original class names, with no additional locals                                     |
 
-In lieu of a string, a custom function can generate the exported class names.
+In lieu of a string, a custom function can generate the exported class names. The function may return either a single string or an array of strings; when an array is returned every entry is added to the locals map and resolves to the same value.
 
 ### Resolve path alias
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare type LocalsConventionFunction = (
 	originalClassName: string,
 	generatedClassName: string,
 	inputFile: string
-) => string;
+) => string | string[];
 
 declare class Loader {
 	constructor(root: string, plugins: Plugin[]);
@@ -24,6 +24,8 @@ declare interface Options {
 		| "camelCaseOnly"
 		| "dashes"
 		| "dashesOnly"
+		| "all"
+		| "none"
 		| LocalsConventionFunction;
 
 	scopeBehaviour?: "global" | "local";

--- a/src/localsConvention.js
+++ b/src/localsConvention.js
@@ -10,12 +10,29 @@ export function makeLocalsConventionReducer(localsConvention, inputFile) {
 	return (tokens, [className, value]) => {
 		if (isFunc) {
 			const convention = localsConvention(className, value, inputFile);
+
+			if (Array.isArray(convention)) {
+				convention.forEach((name) => (tokens[name] = value));
+
+				return tokens;
+			}
+
 			tokens[convention] = value;
 
 			return tokens;
 		}
 
 		switch (localsConvention) {
+			case "none":
+				tokens[className] = value;
+				break;
+
+			case "all":
+				tokens[className] = value;
+				tokens[camelCase(className)] = value;
+				tokens[dashesCamelCase(className)] = value;
+				break;
+
 			case "camelCase":
 				tokens[className] = value;
 				tokens[camelCase(className)] = value;

--- a/test/test.js
+++ b/test/test.js
@@ -279,6 +279,83 @@ it("processes localsConvention with function option", async () => {
 	});
 });
 
+it("processes localsConvention with all option", async () => {
+	const sourceFile = path.join(fixturesPath, "in", "camelCase.css");
+	const source = fs.readFileSync(sourceFile).toString();
+	const jsonFile = path.join(fixturesPath, "in", "camelCase.css.json");
+
+	if (fs.existsSync(jsonFile)) fs.unlinkSync(jsonFile);
+
+	await postcss([plugin({ generateScopedName, localsConvention: "all" })]).process(source, {
+		from: sourceFile,
+	});
+
+	const json = fs.readFileSync(jsonFile).toString();
+	fs.unlinkSync(jsonFile);
+
+	expect(JSON.parse(json)).toMatchObject({
+		"camel-case": "_camelCase_camel-case",
+		camelCase: "_camelCase_camel-case",
+		"camel-case-extra": "_camelCase_camel-case-extra",
+		camelCaseExtra: "_camelCase_camel-case-extra",
+		FooBar: "_camelCase_FooBar",
+		fooBar: "_camelCase_FooBar",
+	});
+});
+
+it("processes localsConvention with none option", async () => {
+	const sourceFile = path.join(fixturesPath, "in", "camelCase.css");
+	const source = fs.readFileSync(sourceFile).toString();
+	const jsonFile = path.join(fixturesPath, "in", "camelCase.css.json");
+
+	if (fs.existsSync(jsonFile)) fs.unlinkSync(jsonFile);
+
+	await postcss([plugin({ generateScopedName, localsConvention: "none" })]).process(source, {
+		from: sourceFile,
+	});
+
+	const json = fs.readFileSync(jsonFile).toString();
+	fs.unlinkSync(jsonFile);
+
+	const result = JSON.parse(json);
+
+	expect(result).toMatchObject({
+		"camel-case": "_camelCase_camel-case",
+		"camel-case-extra": "_camelCase_camel-case-extra",
+		FooBar: "_camelCase_FooBar",
+	});
+	expect(result).not.toHaveProperty("camelCase");
+	expect(result).not.toHaveProperty("camelCaseExtra");
+	expect(result).not.toHaveProperty("fooBar");
+});
+
+it("processes localsConvention function returning an array of aliases", async () => {
+	const sourceFile = path.join(fixturesPath, "in", "camelCase.css");
+	const source = fs.readFileSync(sourceFile).toString();
+	const jsonFile = path.join(fixturesPath, "in", "camelCase.css.json");
+
+	if (fs.existsSync(jsonFile)) fs.unlinkSync(jsonFile);
+
+	await postcss([
+		plugin({
+			generateScopedName,
+			localsConvention: (className) => [className, className.toUpperCase()],
+		}),
+	]).process(source, { from: sourceFile });
+
+	const json = fs.readFileSync(jsonFile).toString();
+	fs.unlinkSync(jsonFile);
+
+	expect(JSON.parse(json)).toMatchObject({
+		"camel-case": "_camelCase_camel-case",
+		"CAMEL-CASE": "_camelCase_camel-case",
+		"camel-case-extra": "_camelCase_camel-case-extra",
+		"CAMEL-CASE-EXTRA": "_camelCase_camel-case-extra",
+		FooBar: "_camelCase_FooBar",
+		FOOBAR: "_camelCase_FooBar",
+	});
+});
+
 it("processes hashPrefix option", async () => {
 	const generateScopedName = "[hash:base64:5]";
 	const hashPrefix = "prefix";


### PR DESCRIPTION
## Summary

Picks up the unmerged work from #154 by @CarbonORM and rebases it onto current master.

The original PR was opened in 2023 against an older codebase and never made it in; this branch ships only the source changes (dropping the stale CI matrix bump and lockfile churn the original had to carry).

## Changes

- New `localsConvention` value **`'all'`** — emit the original class name plus camelCase and dashes-camelCase variants in one go.
- New `localsConvention` value **`'none'`** — emit only the original class name, with no additional aliases.
- The function form of `localsConvention` now accepts an array return. When the callback returns `string[]`, every entry is added to the locals map and resolves to the same value. Useful when a single CSS class should be exposed under multiple JS-friendly names.
- README documents both behaviours.
- `.idea/` is added to `.gitignore`.

## Backwards compatibility

Purely additive — existing modes (`camelCase`, `camelCaseOnly`, `dashes`, `dashesOnly`) and the single-string function return path are unchanged.

## Verification

- `make test` (lint + jest) → 32/32 pass on Node 22 (Docker)

## Credit

Original implementation by @CarbonORM in #154.