### PR TITLE
Fix hashPrefix default-generator regression (#160) and orphan :global rules (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 8.3.1
+
+### Fixed
+
+- `hashPrefix` is now applied when no custom `generateScopedName` is set. Previously the option was only honoured by `generic-names`, so the built-in default generator silently ignored it. [#160](https://github.com/madyankin/postcss-modules/issues/160)
+- Empty rules left behind after `:global { ... }` unwrapping (e.g. a Sass block containing only a multi-line comment) are now removed instead of emitted as orphaned `{ ... }` blocks. [#136](https://github.com/madyankin/postcss-modules/issues/136)
+
 ## 8.3.0
 
 ### Added

--- a/src/pluginFactory.js
+++ b/src/pluginFactory.js
@@ -78,6 +78,12 @@ export function makePlugin(opts) {
 				from: inputFile,
 			});
 
+			// Remove rules whose selector was reduced to whitespace after
+			// `:global { ... }` unwrapping — see #136.
+			css.walkRules((rule) => {
+				if (rule.selector.trim() === "") rule.remove();
+			});
+
 			const out = loader.finalSource;
 			if (out) css.prepend(out);
 

--- a/src/scoping.js
+++ b/src/scoping.js
@@ -33,16 +33,20 @@ export function getDefaultScopeBehaviour(scopeBehaviour) {
 	return scopeBehaviour && isValidBehaviour(scopeBehaviour) ? scopeBehaviour : behaviours.LOCAL;
 }
 
-function generateScopedNameDefault(name, filename, css) {
-	const i = css.indexOf(`.${name}`);
-	const lineNumber = css.substr(0, i).split(/[\r\n]/).length;
-	const hash = stringHash(css).toString(36).substr(0, 5);
+function makeDefaultScopedNameGenerator(hashPrefix) {
+	return function generateScopedNameDefault(name, filename, css) {
+		const i = css.indexOf(`.${name}`);
+		const lineNumber = css.substr(0, i).split(/[\r\n]/).length;
+		const hash = stringHash(`${hashPrefix || ""}${css}`)
+			.toString(36)
+			.substr(0, 5);
 
-	return `_${name}_${hash}_${lineNumber}`;
+		return `_${name}_${hash}_${lineNumber}`;
+	};
 }
 
 export function getScopedNameGenerator(generateScopedName, hashPrefix) {
-	const scopedNameGenerator = generateScopedName || generateScopedNameDefault;
+	const scopedNameGenerator = generateScopedName || makeDefaultScopedNameGenerator(hashPrefix);
 
 	if (typeof scopedNameGenerator === "function") {
 		return scopedNameGenerator;

--- a/test/test.js
+++ b/test/test.js
@@ -374,6 +374,31 @@ it("processes hashPrefix option", async () => {
 	expect(result1.css).not.toEqual(result2.css);
 });
 
+it("drops empty :global rules left behind by Sass-style nesting (#136)", async () => {
+	const source = `:global {\n  /* leading comment */\n}\n:global summary {\n  display: list-item;\n}\n`;
+
+	const result = await postcss([
+		plugin({ generateScopedName: (n) => n, getJSON: () => {} }),
+	]).process(source, { from: "test.css" });
+
+	expect(result.css).not.toMatch(/^\s*\{/m);
+	expect(result.css).toContain("summary {");
+});
+
+it("processes hashPrefix option with the default scope name generator (#160)", async () => {
+	const getJSON = () => {};
+	const withoutHashPrefix = plugin({ getJSON });
+	const withHashPrefix = plugin({ getJSON, hashPrefix: "prefix" });
+
+	const css = ".foo {}";
+	const params = { from: "test.css" };
+
+	const result1 = await postcss([withoutHashPrefix]).process(css, params);
+	const result2 = await postcss([withHashPrefix]).process(css, params);
+
+	expect(result1.css).not.toEqual(result2.css);
+});
+
 it("different instances have different generateScopedName functions", async () => {
 	const one = plugin({
 		generateScopedName: () => "one",


### PR DESCRIPTION
## Summary

Two narrow bug fixes from the open-issue triage:

### #160 — `hashPrefix` not applied with the default scope name generator

When no custom `generateScopedName` template or function was supplied, postcss-modules fell back to a built-in default that hashed the CSS source directly and ignored `hashPrefix`. The prefix only worked when callers used the `[hash:...]` placeholder (handled by `generic-names`).

Fix: thread `hashPrefix` into the default generator and fold it into the input of `stringHash`.

### #136 — Orphan `{ ... }` rules after Sass `:global` unwrap

A `:global { ... }` block containing only a multi-line comment (a common pattern in Sass when a comment is followed by a nested selector) was unwrapped by `postcss-modules-local-by-default`, leaving a rule whose selector was reduced to whitespace. PostCSS dutifully emitted that as `{ /* comment */ }`, producing invalid CSS.

Fix: in the postcss-modules `OnceExit` hook, walk the result and drop rules whose selector trims to an empty string.

## Tests

- 2 new jest cases (one per bug), pre-existing 35 cases still pass → 37/37 in `node:22` Docker.

## Out of scope

- Issue #156 (`getJSON` not called for identical-content files) — I couldn't reproduce against the plugin directly and posted a request for a minimal repro on the issue. Likely a bundler dedupe, not a plugin bug.
- Issue #155 (`generateScopedName` strings + critters) — closed with workaround; upstream is a critters parsing bug.