### PR TITLE
Add Node ESM loader hook for `import styles from './x.css'`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint: node_modules/.installed
 
 compile: node_modules/.installed
 	$(EXEC) swc src -d $(BUILD_DIR) --strip-leading-paths --ignore 'src/*.mjs'
-	$(DOCKER) sh -c 'cp src/*.mjs $(BUILD_DIR)/'
+	cp src/*.mjs $(BUILD_DIR)/
 
 test: lint compile
 	$(EXEC) jest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD_DIR	= ./build
 EXEC		= npm exec --
 
-.PHONY: clean lint test build publish pack release-patch release-minor release-major
+.PHONY: clean lint compile test build publish pack release-patch release-minor release-major
 
 # Reinstall whenever package-lock.json is newer than the marker.
 node_modules/.installed: package-lock.json package.json
@@ -15,11 +15,14 @@ clean:
 lint: node_modules/.installed
 	$(EXEC) eslint src test
 
-test: lint
+compile: node_modules/.installed
+	$(EXEC) swc src -d $(BUILD_DIR) --strip-leading-paths --ignore 'src/*.mjs'
+	$(DOCKER) sh -c 'cp src/*.mjs $(BUILD_DIR)/'
+
+test: lint compile
 	$(EXEC) jest
 
 build: clean test
-	$(EXEC) swc src -d $(BUILD_DIR) --strip-leading-paths
 
 publish: build
 	npm publish ./

--- a/README.md
+++ b/README.md
@@ -92,6 +92,35 @@ postcss([
 
 `getJSON` may also return a `Promise`.
 
+## Using with JavaScript imports
+
+### With a bundler
+
+`import styles from "./x.css"` is already supported by every major bundler — they invoke postcss-modules (or its building blocks) under the hood:
+
+- **webpack** — [`css-loader`](https://github.com/webpack-contrib/css-loader) with `{ modules: true }`
+- **Vite** — built-in, files named `*.module.css`
+- **esbuild** — [`esbuild-css-modules-plugin`](https://github.com/indooorsman/esbuild-css-modules-plugin)
+- **Rollup** — [`rollup-plugin-postcss`](https://github.com/egoist/rollup-plugin-postcss) with `modules: true`
+
+### Without a bundler (SSR, Node scripts, Jest/Vitest in node mode)
+
+For Node directly, install the loader hook:
+
+```sh
+node --import postcss-modules/loader app.mjs
+```
+
+```js
+// app.mjs
+import styles from "./button.css";
+console.log(styles.primary); // "_button__primary_xkpkl_5"
+```
+
+Options live in `postcss-modules.config.{js,cjs,mjs}` in your cwd, or set `POSTCSS_MODULES_CONFIG=/path/to/cfg.cjs`. The config object accepts the same options as the PostCSS plugin (`generateScopedName`, `localsConvention`, `scopeBehaviour`, `globalModulePaths`, `Loader`, `resolve`, …).
+
+Requires Node ≥ 20.6 (the version that stabilized `module.register`). The loader returns only the token map; the transformed CSS is not emitted. For HMR, watch mode, or CSS extraction, use a bundler instead.
+
 ### Generating scoped names
 
 By default, the plugin assumes that all the classes are local. You can change

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ postcss([
 
 ### Without a bundler (SSR, Node scripts, Jest/Vitest in node mode)
 
-For Node directly, install the loader hook:
+`postcss-modules` ships a Node [module-customization hook](https://nodejs.org/api/module.html#customization-hooks) at the `postcss-modules/loader` subpath. Register it with `--import` and any `import` of a `.css` file is intercepted, run through the plugin, and exposed as a default-exported token map.
 
 ```sh
 node --import postcss-modules/loader app.mjs
@@ -114,12 +114,78 @@ node --import postcss-modules/loader app.mjs
 ```js
 // app.mjs
 import styles from "./button.css";
-console.log(styles.primary); // "_button__primary_xkpkl_5"
+
+const el = document.createElement("div");
+el.className = styles.primary; // "_button__primary_xkpkl_5"
 ```
 
-Options live in `postcss-modules.config.{js,cjs,mjs}` in your cwd, or set `POSTCSS_MODULES_CONFIG=/path/to/cfg.cjs`. The config object accepts the same options as the PostCSS plugin (`generateScopedName`, `localsConvention`, `scopeBehaviour`, `globalModulePaths`, `Loader`, `resolve`, …).
+Composing across files (`composes: foo from "./other.css"`) works without extra configuration — the same `FileSystemLoader` the PostCSS plugin uses resolves siblings.
 
-Requires Node ≥ 20.6 (the version that stabilized `module.register`). The loader returns only the token map; the transformed CSS is not emitted. For HMR, watch mode, or CSS extraction, use a bundler instead.
+#### Configuring the loader
+
+The hook accepts the same options object as the PostCSS plugin
+(`generateScopedName`, `localsConvention`, `scopeBehaviour`, `globalModulePaths`, `exportGlobals`, `hashPrefix`, `Loader`, `resolve`, `root`). Options are discovered, in priority order:
+
+1. `process.env.POSTCSS_MODULES_CONFIG` — absolute or cwd-relative path to a config file.
+2. `postcss-modules.config.{js,cjs,mjs}` in `process.cwd()`.
+3. A `"postcss-modules"` key in the nearest `package.json`.
+4. Empty defaults.
+
+Example config file:
+
+```js
+// postcss-modules.config.cjs
+module.exports = {
+	generateScopedName: "[name]__[local]___[hash:base64:5]",
+	localsConvention: "camelCaseOnly",
+};
+```
+
+Or inline in `package.json`:
+
+```json
+{
+	"postcss-modules": {
+		"generateScopedName": "[name]__[local]___[hash:base64:5]"
+	}
+}
+```
+
+Or via an environment variable, useful for per-environment overrides:
+
+```sh
+POSTCSS_MODULES_CONFIG=./config/css-modules.cjs node --import postcss-modules/loader app.mjs
+```
+
+#### Jest / Vitest
+
+Both runners accept the same `--import` flag through their Node options.
+
+```sh
+NODE_OPTIONS="--import postcss-modules/loader" jest
+NODE_OPTIONS="--import postcss-modules/loader" vitest
+```
+
+Or wire it into a setup file. The loader runs once per worker, so spawned worker pools (Jest's default) pick it up automatically.
+
+#### TypeScript
+
+Add an ambient declaration so the compiler accepts default-importing a `.css` file:
+
+```ts
+// css-modules.d.ts
+declare module "*.css" {
+	const tokens: { readonly [key: string]: string };
+	export default tokens;
+}
+```
+
+#### Limitations
+
+- **ESM only.** `require("./x.css")` is not supported; the underlying transform is async and cannot be expressed through `require.extensions`. Use a `.mjs` entrypoint, or `"type": "module"` in `package.json`.
+- **Tokens only, no CSS output.** The loader returns the class-name map but does not emit the transformed CSS. SSR setups that need the stylesheet should use a bundler or call `postcss([require("postcss-modules")(...)]).process(...)` directly to capture both.
+- **No HMR, no watch mode** — by design. Use a bundler for those.
+- **Node ≥ 20.6.** `module.register` stabilized there.
 
 ### Generating scoped names
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,3 +50,5 @@ declare interface PostcssModulesPlugin {
 declare const PostcssModulesPlugin: PostcssModulesPlugin;
 
 export = PostcssModulesPlugin;
+
+declare module "postcss-modules/loader" {}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
 	"description": "PostCSS plugin to use CSS Modules everywhere",
 	"main": "build/index.js",
 	"types": "index.d.ts",
+	"exports": {
+		".": {
+			"types": "./index.d.ts",
+			"default": "./build/index.js"
+		},
+		"./loader": "./build/loader.mjs",
+		"./package.json": "./package.json"
+	},
 	"keywords": [
 		"postcss",
 		"css",
@@ -48,7 +56,7 @@
 		"prettier": "^3.9.4"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=20.6"
 	},
 	"scripts": {
 		"test": "make test",

--- a/src/loadConfig.mjs
+++ b/src/loadConfig.mjs
@@ -1,0 +1,43 @@
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import path from "path";
+import { pathToFileURL } from "url";
+
+const CONFIG_NAMES = [
+	"postcss-modules.config.js",
+	"postcss-modules.config.cjs",
+	"postcss-modules.config.mjs",
+];
+
+async function importConfig(filePath) {
+	const url = pathToFileURL(filePath).href;
+	const mod = await import(url);
+	return mod.default || mod;
+}
+
+export async function loadConfig(cwd = process.cwd()) {
+	const explicit = process.env.POSTCSS_MODULES_CONFIG;
+	if (explicit) {
+		const resolved = path.isAbsolute(explicit) ? explicit : path.resolve(cwd, explicit);
+		return importConfig(resolved);
+	}
+
+	for (const name of CONFIG_NAMES) {
+		const candidate = path.resolve(cwd, name);
+		if (existsSync(candidate)) {
+			return importConfig(candidate);
+		}
+	}
+
+	const pkgPath = path.resolve(cwd, "package.json");
+	if (existsSync(pkgPath)) {
+		try {
+			const pkg = JSON.parse(await readFile(pkgPath, "utf8"));
+			if (pkg["postcss-modules"]) return pkg["postcss-modules"];
+		} catch {
+			// ignore unreadable / malformed package.json
+		}
+	}
+
+	return {};
+}

--- a/src/loader.mjs
+++ b/src/loader.mjs
@@ -1,0 +1,3 @@
+import { register } from "node:module";
+
+register("./loaderHooks.mjs", import.meta.url);

--- a/src/loaderHooks.mjs
+++ b/src/loaderHooks.mjs
@@ -1,0 +1,25 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { processCSS } from "./processCSS.js";
+import { loadConfig } from "./loadConfig.mjs";
+
+let configPromise;
+function getConfig() {
+	if (!configPromise) configPromise = loadConfig();
+	return configPromise;
+}
+
+export async function load(url, context, nextLoad) {
+	if (!url.startsWith("file:") || !url.endsWith(".css")) {
+		return nextLoad(url, context);
+	}
+	const filename = fileURLToPath(url);
+	const source = await readFile(filename, "utf8");
+	const opts = await getConfig();
+	const tokens = await processCSS(source, filename, opts);
+	return {
+		format: "module",
+		source: `export default ${JSON.stringify(tokens)};\n`,
+		shortCircuit: true,
+	};
+}

--- a/src/processCSS.js
+++ b/src/processCSS.js
@@ -1,0 +1,18 @@
+import postcss from "postcss";
+import { readFile, writeFile } from "fs";
+import { setFileSystem } from "./fs";
+import { makePlugin } from "./pluginFactory";
+
+setFileSystem({ readFile, writeFile });
+
+export async function processCSS(source, filename, opts = {}) {
+	let tokens = {};
+	const plugin = makePlugin({
+		...opts,
+		getJSON: (_cssFile, json) => {
+			tokens = json;
+		},
+	});
+	await postcss([plugin]).process(source, { from: filename });
+	return tokens;
+}

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -2,10 +2,14 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const repoRoot = path.resolve(__dirname, "..");
 const loaderPath = path.resolve(repoRoot, "build/loader.mjs");
+const loaderUrl = pathToFileURL(loaderPath).href;
 const fixturesIn = path.resolve(__dirname, "./fixtures/in");
+
+const toImportSpecifier = (filePath) => pathToFileURL(filePath).href;
 
 beforeAll(() => {
 	if (!existsSync(loaderPath)) {
@@ -18,7 +22,7 @@ beforeAll(() => {
 function runLoaderScript(script, options = {}) {
 	return execFileSync(
 		process.execPath,
-		["--import", loaderPath, "--input-type=module", "-e", script],
+		["--import", loaderUrl, "--input-type=module", "-e", script],
 		{
 			cwd: options.cwd || repoRoot,
 			encoding: "utf8",
@@ -30,7 +34,7 @@ function runLoaderScript(script, options = {}) {
 it("returns the token map for a CSS file via JS import", () => {
 	const cssPath = path.join(fixturesIn, "classes.css");
 	const out = runLoaderScript(
-		`import s from ${JSON.stringify(cssPath)}; process.stdout.write(JSON.stringify(s));`,
+		`import s from ${JSON.stringify(toImportSpecifier(cssPath))}; process.stdout.write(JSON.stringify(s));`,
 	);
 	const tokens = JSON.parse(out);
 	expect(Object.keys(tokens).sort()).toEqual(["article", "title"]);
@@ -40,7 +44,7 @@ it("returns the token map for a CSS file via JS import", () => {
 it("composes tokens across imported CSS files", () => {
 	const cssPath = path.join(fixturesIn, "composes.css");
 	const out = runLoaderScript(
-		`import s from ${JSON.stringify(cssPath)}; process.stdout.write(JSON.stringify(s));`,
+		`import s from ${JSON.stringify(toImportSpecifier(cssPath))}; process.stdout.write(JSON.stringify(s));`,
 	);
 	const tokens = JSON.parse(out);
 	expect(tokens).toHaveProperty("title");
@@ -59,7 +63,7 @@ it("applies options from postcss-modules.config.cjs in cwd", () => {
 		const cssPath = path.join(dir, "x.css");
 		writeFileSync(cssPath, ".foo { color: red; }\n.bar { color: blue; }\n");
 		const out = runLoaderScript(
-			`import s from ${JSON.stringify(cssPath)}; process.stdout.write(JSON.stringify(s));`,
+			`import s from ${JSON.stringify(toImportSpecifier(cssPath))}; process.stdout.write(JSON.stringify(s));`,
 			{ cwd: dir },
 		);
 		expect(JSON.parse(out)).toEqual({ foo: "_test_foo", bar: "_test_bar" });
@@ -79,7 +83,7 @@ it("honors POSTCSS_MODULES_CONFIG env var", () => {
 		const cssPath = path.join(dir, "x.css");
 		writeFileSync(cssPath, ".a {}\n.b {}\n");
 		const out = runLoaderScript(
-			`import s from ${JSON.stringify(cssPath)}; process.stdout.write(JSON.stringify(s));`,
+			`import s from ${JSON.stringify(toImportSpecifier(cssPath))}; process.stdout.write(JSON.stringify(s));`,
 			{ cwd: dir, env: { POSTCSS_MODULES_CONFIG: configPath } },
 		);
 		expect(JSON.parse(out)).toEqual({ a: "_env_a", b: "_env_b" });
@@ -92,7 +96,7 @@ it("surfaces missing-file errors with the source path", () => {
 	const cssPath = path.join(fixturesIn, "does-not-exist.css");
 	expect(() => {
 		runLoaderScript(
-			`import s from ${JSON.stringify(cssPath)}; process.stdout.write(JSON.stringify(s));`,
+			`import s from ${JSON.stringify(toImportSpecifier(cssPath))}; process.stdout.write(JSON.stringify(s));`,
 		);
 	}).toThrow(/does-not-exist\.css/);
 });

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,0 +1,98 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const repoRoot = path.resolve(__dirname, "..");
+const loaderPath = path.resolve(repoRoot, "build/loader.mjs");
+const fixturesIn = path.resolve(__dirname, "./fixtures/in");
+
+beforeAll(() => {
+	if (!existsSync(loaderPath)) {
+		throw new Error(
+			`Loader build artifact missing at ${loaderPath}. Run \`make compile\` first.`,
+		);
+	}
+});
+
+function runLoaderScript(script, options = {}) {
+	return execFileSync(
+		process.execPath,
+		["--import", loaderPath, "--input-type=module", "-e", script],
+		{
+			cwd: options.cwd || repoRoot,
+			encoding: "utf8",
+			env: { ...process.env, ...(options.env || {}) },
+		},
+	).trim();
+}
+
+it("returns the token map for a CSS file via JS import", () => {
+	const cssPath = path.join(fixturesIn, "classes.css");
+	const out = runLoaderScript(
+		`import s from ${JSON.stringify(cssPath)}; process.stdout.write(JSON.stringify(s));`,
+	);
+	const tokens = JSON.parse(out);
+	expect(Object.keys(tokens).sort()).toEqual(["article", "title"]);
+	expect(tokens.title).toMatch(/title/);
+});
+
+it("composes tokens across imported CSS files", () => {
+	const cssPath = path.join(fixturesIn, "composes.css");
+	const out = runLoaderScript(
+		`import s from ${JSON.stringify(cssPath)}; process.stdout.write(JSON.stringify(s));`,
+	);
+	const tokens = JSON.parse(out);
+	expect(tokens).toHaveProperty("title");
+	expect(tokens).toHaveProperty("figure");
+	expect(tokens.title.split(/\s+/).length).toBeGreaterThanOrEqual(2);
+	expect(tokens.figure.split(/\s+/).length).toBeGreaterThanOrEqual(2);
+});
+
+it("applies options from postcss-modules.config.cjs in cwd", () => {
+	const dir = mkdtempSync(path.join(tmpdir(), "pcm-loader-"));
+	try {
+		writeFileSync(
+			path.join(dir, "postcss-modules.config.cjs"),
+			'module.exports = { generateScopedName: (name) => "_test_" + name };\n',
+		);
+		const cssPath = path.join(dir, "x.css");
+		writeFileSync(cssPath, ".foo { color: red; }\n.bar { color: blue; }\n");
+		const out = runLoaderScript(
+			`import s from ${JSON.stringify(cssPath)}; process.stdout.write(JSON.stringify(s));`,
+			{ cwd: dir },
+		);
+		expect(JSON.parse(out)).toEqual({ foo: "_test_foo", bar: "_test_bar" });
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+it("honors POSTCSS_MODULES_CONFIG env var", () => {
+	const dir = mkdtempSync(path.join(tmpdir(), "pcm-loader-env-"));
+	try {
+		const configPath = path.join(dir, "my-config.cjs");
+		writeFileSync(
+			configPath,
+			'module.exports = { generateScopedName: (name) => "_env_" + name };\n',
+		);
+		const cssPath = path.join(dir, "x.css");
+		writeFileSync(cssPath, ".a {}\n.b {}\n");
+		const out = runLoaderScript(
+			`import s from ${JSON.stringify(cssPath)}; process.stdout.write(JSON.stringify(s));`,
+			{ cwd: dir, env: { POSTCSS_MODULES_CONFIG: configPath } },
+		);
+		expect(JSON.parse(out)).toEqual({ a: "_env_a", b: "_env_b" });
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+it("surfaces missing-file errors with the source path", () => {
+	const cssPath = path.join(fixturesIn, "does-not-exist.css");
+	expect(() => {
+		runLoaderScript(
+			`import s from ${JSON.stringify(cssPath)}; process.stdout.write(JSON.stringify(s));`,
+		);
+	}).toThrow(/does-not-exist\.css/);
+});


### PR DESCRIPTION
## Summary

- Adds an opt-in `postcss-modules/loader` entrypoint — a Node module-customization hook that lets JavaScript files do `import styles from './foo.css'` and receive the token map directly. Mirrors the workflow `css-loader` and Vite's built-in CSS-Modules handling already provide.
- Aimed at **non-bundler use cases** (SSR, Node scripts, Jest/Vitest in node mode). Bundler users keep using their existing integrations; nothing about the existing plugin path changes.
- Options resolved from `postcss-modules.config.{js,cjs,mjs}` in cwd, `POSTCSS_MODULES_CONFIG` env var, or a `"postcss-modules"` key in `package.json`. Same shape as the PostCSS plugin options.
- Closes #80.

## Usage

```sh
node --import postcss-modules/loader app.mjs
```

```js
// app.mjs
import styles from "./button.css";
console.log(styles.primary); // "_button__primary_xkpkl_5"
```

## Implementation notes

- `src/loader.mjs` — entry; calls `module.register` on the hooks module.
- `src/loaderHooks.mjs` — `load` hook intercepts `file://*.css` URLs, runs them through the existing plugin with a `getJSON` callback that captures tokens, returns a synthetic ESM source.
- `src/processCSS.js` — small helper that sets up the fs adapter and invokes the existing `makePlugin` pipeline (no new code path through the transformer).
- `src/loadConfig.mjs` — config resolver. Kept as `.mjs` so swc doesn't rewrite its dynamic `import()` to `require()`.
- `Makefile` gets a `compile` target; swc ignores `*.mjs` and we `cp` those verbatim into `build/`.
- `package.json` exports map adds `"./loader"`. `engines.node` bumped to `>=20.6` (where `module.register` stabilized).

## Limitations (called out in the README)

- Returns the token map only; the transformed CSS is not emitted. SSR users who also need the CSS should use a bundler.
- No HMR / watch mode — by design.

## Test plan

- [x] `make test` — 42 passing (5 new loader cases + 37 existing), lint clean.
- New cases cover: simple class set, composes-across-files, `postcss-modules.config.cjs` discovery from cwd, `POSTCSS_MODULES_CONFIG` env var override, missing-file error surfaces the source path.
- [ ] Smoke test against a real consumer:
  ```sh
  mkdir /tmp/pcm && cd /tmp/pcm && npm init -y && npm link postcss-modules
  echo '.primary { color: red; }' > button.css
  echo 'import s from "./button.css"; console.log(s);' > app.mjs
  node --import postcss-modules/loader app.mjs
  ```